### PR TITLE
Merge release/1.17.0 into master

### DIFF
--- a/source/includes/_deprecations.md
+++ b/source/includes/_deprecations.md
@@ -1,18 +1,10 @@
 # Deprecation Schedule
 Below you can find a list of deprecated API features, as well as the information on when those features will be removed
-from the API. Since we follow semantic versioning for the API, only major releases will include breaking changes.
+from the API.
 
 Please note that the "Planned Removal" column indicates the date or API version that will fully remove the feature from
 the API. Please ensure that any code using a deprecated feature is updated as soon as possible.
 
 Feature | Replaced By | Deprecated In | Planned Removal
 ------- | ----------- | :-----------: | :-------------:
-`Weapon.attributes.damageType` field | [`Weapon.damageType`](#weapon-fields) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
-`Weapon.attributes.elderseal` field | [`Weapon.elderseal`](#weapon-fields) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
-`Weapon.attributes.phialType` field | [`Weapon.phialType`](#phial-type) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
-`Weapon.attributes.ammoCapacities` field | [`Weapon.ammo`](#ammo-capacities) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
-`Weapon.attributes.coatings` field | [`Weapon.coatings`](#bow-coatings) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
-`Weapon.attributes.specialAmmo` field | [`Weapon.specialAmmo`](#special-ammo) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
-`Weapon.attributes.deviation` field | [`Weapon.deviation`](#deviation) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
-`Weapon.attributes.boostType` field | [`Weapon.boostType`](#boost-type) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
-`Weapon.attributes.shellingType` field | [`Weapon.shelling`](#shelling-type) | [1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) | v1.17.0
+All `.length` fields | The [`$size` operator](#related-object-arrays) | [1.17.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.17.0) | v1.18.0

--- a/source/includes/_endpoints_events.md
+++ b/source/includes/_endpoints_events.md
@@ -21,6 +21,7 @@ fetch('https://mhw-db.com/events')
     "platform": "console",
     "exclusive": null,
     "type": "event quest",
+    "expansion": "base",
     "description": "You and your entire party will have...",
     "requirements": "HR 50 or higher",
     "questRank": 9,
@@ -32,8 +33,7 @@ fetch('https://mhw-db.com/events')
 ]
 ```
 
-This endpoint retrieves all ongoing and scheduled in-game events, pulled from the official Capcom events pages
-([PC](http://game.capcom.com/world/steam/us/schedule.html) and [console](http://game.capcom.com/world/us/schedule.html)).
+This endpoint retrieves all ongoing and scheduled in-game events, pulled from the official Capcom event pages.
 
 Events are updated once per day, at midnight UTC. During the daily update, newly scheduled events will be added to the
 system, while events that have ended will be removed.
@@ -71,6 +71,7 @@ fetch('https://mhw-db.com/events/1')
   "platform": "console",
   "exclusive": null,
   "type": "event quest",
+  "expansion": "base",
   "description": "You and your entire party will have...",
   "requirements": "HR 50 or higher",
   "questRank": 9,
@@ -107,6 +108,7 @@ This endpoint returns a single event. For field information, see the [Event Fiel
   "platform": "console",
   "exclusive": null,
   "type": "event quest",
+  "expansion": "base",
   "description": "You and your entire party will have...",
   "requirements": "HR 50 or higher",
   "questRank": 9,
@@ -131,6 +133,7 @@ name | String | The event's title
 platform | [EventPlatform](#event-platforms) | The platform that the event is running on (if an event is running on more than one platform, each platform will have it's own event object in the API)
 exclusive | [EventExclusivity](#event-exclusivity-types) | For consoles, a value other than `null` indicates that the event is only running on a specific console
 type | [EventType](#event-types) | The event's type
+expansion | [Expansion](#expansion-types) | The expansion that's required in order to access the event
 description | String | A text description of the event
 requires | String | A text description of the event's entry requirements
 questRank | Integer | The rank of the quest
@@ -139,17 +142,24 @@ startTimestamp | DateTime | A timestamp indicating when the event started
 endTimestamp | DateTime | A timestamp indicating when the event will end
 location | [Location](#location-fields) | The location in which the event takes place
 
+### Expansion Types
+An event's `expansion` field may be one of the following values.
+
+- `base`
+- `iceborne`
+
 ### Event Types
-An event's type may be one of the following values.
+An event's `type` field may be one of the following values.
 
 - `kulve taroth siege`
+- `safi'jiiva siege`
 - `event quest`
 - `challenge quest`
 
 Event types correspond to the section on the event page under which the event is listed.
 
 ### Event Platforms
-An event's platform may be one of the following values.
+An event's `platform` field may be one of the following values.
 
 - `pc`
 - `console`

--- a/source/includes/_searching.md
+++ b/source/includes/_searching.md
@@ -22,8 +22,10 @@ Any field in the API that is an ID of another object or a collection of API obje
 ## Related Object Arrays
 ```json
 {
-  "crafting.branches.length": {
-    "$gte": 1
+  "crafting.branches": {
+    "$size": {
+      "$gte": 1
+    }
   }
 }
 ```
@@ -32,13 +34,15 @@ Any field in the API that is an ID of another object or a collection of API obje
 
 ```json
 {
-  "crafting.branches.length": 0
+  "crafting.branches": {
+    "$size": 0
+  }
 }
 ```
 
 > Applied to `/weapons`, returns any weapon that can't be upgraded any further (i.e. is the final weapon in it's tree).
 
-Any field whose values is an array of related objects (such as `Armor.skills` or `Charm.ranks`) can be filtered by it's length by adding `.length` after the field name in your search. This will work for ANY array of objects in the API, and supports filtering using any operator.
+Any field whose values is an array of related objects (such as `Armor.skills` or `Charm.ranks`) can be filtered by it's length by using the `$size`operator on the field. This will work for ANY array of objects in the API, and supports filtering using more complicated operators, such as `$in` or `$gte`.
 
 For examples, please see the example query documents to the right.
 


### PR DESCRIPTION
## Changelog
- Added "fanged beast" as a monster species.
- Iceborne events are now included in the API.
- Relationship length can now be queried using the [`$size` operator](https://docs.mhw-db.com/#related-object-arrays).

## Breaking Changes
- Fields deprecated in [v1.16.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.16.0) have been removed.

## Deprecations
- On all objects, the `.length` fields are now deprecated in favor of the `$size` operator for querying relationship length.
