### PR TITLE
Merge release/1.18.0 into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Monster Hunter World API
-Hey there! Welcome to the docs repository for the Monster Hunter World API. To view the docs, please visit the [GitHub Pages](https://docs.mhw-db.com/) site. If you're interested in contributing to the project, feel free to take a look at [the source code](https://github.com/LartTyler/MHWDB-API). If you have any comments, suggestions, or just wanna say hey, join the project's
-[Gitter](https://gitter.im/mhw-db/general) chat!
+Hey there! Welcome to the docs repository for the Monster Hunter World API. To view the docs, please visit the
+[GitHub Pages](https://docs.mhw-db.com/) site. If you're interested in contributing to the project, feel free to take a
+look at [the source code](https://github.com/LartTyler/MHWDB-API). If you have any comments, suggestions, or just wanna
+say hey, join the project's [Discord server](https://discord.gg/6GEHHQh)!
 
-Also, a huge thanks to everyone that's submitted issues and feedback, it's been a great help! It's really awesome seeing people making use of the project, and I'm excited to see what kinds of applications people end up building with it.
+Also, a huge thanks to everyone that's submitted issues and feedback, it's been a great help! It's really awesome seeing
+people making use of the project, and I'm excited to see what kinds of applications people end up building with it.

--- a/source/includes/_deprecations.md
+++ b/source/includes/_deprecations.md
@@ -7,4 +7,4 @@ the API. Please ensure that any code using a deprecated feature is updated as so
 
 Feature | Replaced By | Deprecated In | Planned Removal
 ------- | ----------- | :-----------: | :-------------:
-All `.length` fields | The [`$size` operator](#related-object-arrays) | [1.17.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.17.0) | v1.18.0
+`CharmRank.name` | N/A | [1.18.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.18.0) | v1.19.0

--- a/source/includes/_endpoints_charms.md
+++ b/source/includes/_endpoints_charms.md
@@ -24,7 +24,6 @@ fetch('https://mhw-db.com/charms')
     "name": "Poison Charm",
     "ranks": [
       {
-        "name": "Poison Charm 1",
         "level": 1,
         "rarity": 3,
         "skills": [...],
@@ -74,7 +73,6 @@ fetch('https://mhw-db.com/charms/234')
   "name": "Poison Charm",
   "ranks": [
     {
-      "name": "Poison Charm 1",
       "level": 1,
       "rarity": 3,
       "skills": [...],
@@ -113,7 +111,6 @@ This endpoint returns a single charm and all of it's ranks. For field informatio
   "name": "Poison Charm",
   "ranks": [
     {
-      "name": "Poison Charm 1",
       "level": 1,
       "rarity": 3,
       "skills": [
@@ -164,7 +161,6 @@ represented as ranks under a [Charm](#charm-fields) object, which groups them to
 
 Field | Type | Description
 ----- | ---- | -----------
-name | String | The name of the charm rank (includes level)
 level | Integer | The level of the charm rank
 rarity | Integer | The rarity of the charm rank
 skills | Array&lt;[SkillRank](#skillrank-fields)&gt; | An array of skill ranks provided by the charm

--- a/source/includes/_endpoints_weapons.md
+++ b/source/includes/_endpoints_weapons.md
@@ -122,7 +122,8 @@ This endpoint returns a single weapon. For field information, see the [Weapon Fi
       "yellow": 50,
       "green": 80,
       "blue": 30,
-      "white": 0
+      "white": 0,
+      "purple": 0
     },
     ...
   ],
@@ -256,6 +257,7 @@ yellow | Integer | The number of normal hits the weapon can make at yellow sharp
 green | Integer | The number of normal hits the weapon can make at green sharpness
 blue | Integer | The number of normal hits the weapon can make at blue sharpness
 white | Integer | The number of normal hits the weapon can make at white sharpness
+purple | Integer | The number of normal hits the weapon can make at purple sharpness
 
 In previous versions, these docs provided a simple method for visually representing sharpness values, since they were
 represented as percetages (which could be mapped 1:1 to pixels for a 100px wide sharpness bar). You can achieve the
@@ -263,8 +265,8 @@ same result by taking the new sharpness values and using the following formula t
 value, then flooring the result: <code>&lfloor;sharpness / 400 * 100&rfloor;</code>.
 
 So, for example, the long sword "<a href="https://mhw-db.com/weapons/156" target="_blank">Dark Scimitar 3</a>" has a
-base durability of 110 red, 30 orange, 60 yellow, 80 green, 40 blue, and 30 white. This converts to the old system as
-follows.
+base durability of 110 red, 30 orange, 60 yellow, 80 green, 40 blue, 30 white, and 0 purple. This converts to the old
+system as follows.
 
 <code>
 Red: &lfloor;110 / 400 * 100&rfloor; = 27<br>
@@ -272,10 +274,11 @@ Orange: &lfloor;30 / 400 * 100&rfloor; = 7<br>
 Yellow: &lfloor;60 / 400 * 100&rfloor; = 15<br>
 Green: &lfloor;80 / 400 * 100&rfloor; = 20<br>
 Blue: &lfloor;40 / 400 * 100&rfloor; = 10<br>
-Red: &lfloor;30 / 400 * 100&rfloor; = 7
+Red: &lfloor;30 / 400 * 100&rfloor; = 7<br>
+Purple: &lfloor;0 / 400 * 100&rfloor; = 0
 </code>
 
-Since, for a 100px wide bar, those percentages map 1:1, the resulting bar would look something like the bar below.
+The resulting bar would look something like the bar below.
 
 <div class="sharpness-bar">
   <div class="red" style="width: 27px"></div>
@@ -284,6 +287,7 @@ Since, for a 100px wide bar, those percentages map 1:1, the resulting bar would 
   <div class="green" style="width: 20px;"></div>
   <div class="blue" style="width: 10px;"></div>
   <div class="white" style="width: 7px;"></div>
+  <div class="purple" style="width: 0px;"></div>
 
   <div class="clearfix"></div>
 </div>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -8,6 +8,8 @@ language_tabs: # must be one of https://git.io/vQNgJ
 toc_footers:
   - <a href="https://github.com/LartTyler/MHWDB-API">View the Project On GitHub</a>
   - <a href="https://github.com/LartTyler/MHWDB-Docs/issues">Report a Bug / Request a Feature</a>
+  - <a href="https://discord.gg/6GEHHQh">Join Us On Discord</a>
+  - <a href="https://contrib.mhw-db.com">Browse the API</a>
   - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
 
 includes:
@@ -34,3 +36,34 @@ search: true
 
 # Introduction
 Welcome to the API docs for [https://mhw-db.com](https://mhw-db.com).
+
+We are currently looking for help with data entry and validation. We also always welcome feedback and suggestions.
+Interesting in contributing to the project? [Join us on Discord!](https://discord.gg/6GEHHQh)
+
+## Accessing the API
+All data in the API can be accessed using the base URL `https://mhw-db.com`. You may optionally include a language tag
+as the prefix to any route in the API, in order to retrieve results that have been translated to a specific language.
+For a list of supported language tags, see the section on [Localization](#localization) below.
+
+Example code and URLs in the rest of this documentation will not include any language tag prefixes for the sake of
+readability.
+
+## Localization
+Currently, the API supports the following languages.
+
+|Language|Tag|
+|---|---|
+|English|&mdash;|
+|French|`fr`|
+|German|`de`|
+|Chinese (simplified)|`zh`|
+|Chinese (traditional)|`zh-Hant`|
+
+The default language is English, and does not require a language tag prefix on any route. To switch to any other
+language, simply prefix the route with the tag, e.g. `https://mhw-db.com/zh-Hant/weapons/1`.
+
+**Please be aware** that not all supported languages will contain localized data, and may return `null` values for
+string fields. Localization requires manual data entry, and we're working through getting localized names into the API
+as quickly as possible. If you would like to help with localization, please reach out to me at
+[tyler@lartonoix.com](mailto:tyler@lartonoix.com), or contact us via the [Discord server](https://discord.gg/6GEHHQh)
+linked in the sidebar.

--- a/source/stylesheets/_sharpness-bar.scss
+++ b/source/stylesheets/_sharpness-bar.scss
@@ -5,6 +5,7 @@ $colors: (
 	'green': #81b034,
 	'blue': #3a58d7,
 	'white': #e2e2e2,
+	'purple': #885aec,
 );
 
 .sharpness-bar {


### PR DESCRIPTION
## Changelog
- Added support for localization. Please read the [docs on localization](https://docs.mhw-db.com/#localization) for more information.
- Added support for purple sharpness.

## Breaking Changes
- Fields deprecated in [v1.17.0](https://github.com/LartTyler/MHWDB-Docs/releases/tag/1.17.0) have been removed.

## Deprecations
- On `CharmRank` objects, the `name` field is now deprecated, and will be removed in v1.19.0.